### PR TITLE
Removed deprecated array_get and used Arr::get() in in Setting.php

### DIFF
--- a/src/Setting/Setting.php
+++ b/src/Setting/Setting.php
@@ -3,6 +3,7 @@
 namespace Unisharp\Setting;
 
 use Illuminate\Contracts\Cache\Factory as CacheContract;
+use Illuminate\Support\Arr;
 
 class Setting
 {
@@ -226,7 +227,7 @@ class Setting
 
         $subkey = $this->removeMainKey($key);
 
-        $setting = array_get($setting, $subkey);
+        $setting = Arr::get($setting, $subkey);
 
         return $setting;
     }


### PR DESCRIPTION
## Summary of Change
The use of `array_get` results in undefined function in Laravel 6 because of the deprecated (now removed) `array_*` functions in Laravel 6.

I replaced `array_get` with `Arr::get` to make this work.